### PR TITLE
Add tests for pyramid boundary checks

### DIFF
--- a/tests/test_annotation_tilerendering.py
+++ b/tests/test_annotation_tilerendering.py
@@ -95,6 +95,16 @@ def test_tile_generator_len(fill_store: Callable, tmp_path: Path) -> None:
     assert len(tg) == (4 * 4) + (2 * 2) + 1
 
 
+def test_tile_grid_size_too_high_level(fill_store: Callable, tmp_path: Path) -> None:
+    """Expect IndexError when requesting tile grid for out of range level."""
+    array = np.ones((1024, 1024))
+    wsi = wsireader.VirtualWSIReader(array, mpp=(1, 1))
+    _, store = fill_store(SQLiteStore, tmp_path / "test.db")
+    tg = AnnotationTileGenerator(wsi.info, store, tile_size=256)
+    with pytest.raises(IndexError):
+        tg.tile_grid_size(tg.level_count)
+
+
 def test_tile_generator_iter(fill_store: Callable, tmp_path: Path) -> None:
     """Test __iter__ for AnnotationTileGenerator."""
     array = np.ones((1024, 1024))
@@ -229,6 +239,17 @@ def test_get_tile_large_level(fill_store: Callable, tmp_path: Path) -> None:
     tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
     with pytest.raises(IndexError):
         tg.get_tile(100, 0, 0)
+
+
+def test_get_tile_level_count(fill_store: Callable, tmp_path: Path) -> None:
+    """Expect IndexError when level == level_count."""
+    array = np.ones((1024, 1024))
+    wsi = wsireader.VirtualWSIReader(array)
+    _, store = fill_store(SQLiteStore, tmp_path / "test.db")
+    renderer = AnnotationRenderer(max_scale=1, edge_thickness=0)
+    tg = AnnotationTileGenerator(wsi.info, store, renderer, tile_size=256)
+    with pytest.raises(IndexError):
+        tg.get_tile(tg.level_count, 0, 0)
 
 
 def test_get_tile_large_xy(fill_store: Callable, tmp_path: Path) -> None:

--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -59,6 +59,15 @@ def test_tile_grid_size_invalid_level() -> None:
     dz.tile_grid_size(level=0)
 
 
+def test_tile_grid_size_too_high_level() -> None:
+    """Test tile_grid_size raises IndexError when level == level_count."""
+    array = np.ones((1024, 1024))
+    wsi = wsireader.VirtualWSIReader(array)
+    dz = pyramid.ZoomifyGenerator(wsi, tile_size=256)
+    with pytest.raises(IndexError):
+        dz.tile_grid_size(dz.level_count)
+
+
 def test_get_tile_negative_level() -> None:
     """Test for IndexError on negative levels."""
     array = np.ones((1024, 1024))
@@ -75,6 +84,15 @@ def test_get_tile_large_level() -> None:
     dz = pyramid.ZoomifyGenerator(wsi, tile_size=256)
     with pytest.raises(IndexError):
         dz.get_tile(100, 0, 0)
+
+
+def test_get_tile_level_count() -> None:
+    """Test for IndexError when level == level_count."""
+    array = np.ones((1024, 1024))
+    wsi = wsireader.VirtualWSIReader(array)
+    dz = pyramid.ZoomifyGenerator(wsi, tile_size=256)
+    with pytest.raises(IndexError):
+        dz.get_tile(dz.level_count, 0, 0)
 
 
 def test_get_tile_large_xy() -> None:


### PR DESCRIPTION
## Summary
- add tests for calling tile grid or tile getter at level_count
- add equivalent tests for AnnotationTileGenerator

## Testing
- `ruff check tests/test_pyramid.py tests/test_annotation_tilerendering.py`
- `pytest -q` *(fails: `pytest` not found)*