### PR TITLE
Add basic OpenLayers viewer

### DIFF
--- a/tiatoolbox/visualization/openlayers_app/__init__.py
+++ b/tiatoolbox/visualization/openlayers_app/__init__.py
@@ -1,0 +1,1 @@
+"""OpenLayers based viewer."""

--- a/tiatoolbox/visualization/openlayers_app/app.py
+++ b/tiatoolbox/visualization/openlayers_app/app.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tiatoolbox.visualization.tileserver import TileServer
+
+
+def create_app(slide: str | None = None) -> TileServer:
+    layers = {}
+    if slide is not None:
+        layers = {"slide": slide}
+    app = TileServer(title="TIAToolbox OpenLayers", layers=layers)
+    tpl = Path(__file__).parent / "templates"
+    static = Path(__file__).parent / "static"
+    app.jinja_loader.searchpath.insert(0, str(tpl))
+    app.static_folder = str(static)
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(host="0.0.0.0", threaded=True)

--- a/tiatoolbox/visualization/openlayers_app/static/main.js
+++ b/tiatoolbox/visualization/openlayers_app/static/main.js
@@ -1,0 +1,54 @@
+function init() {
+    var dataElement = document.getElementById('map');
+    var layersData = JSON.parse(dataElement.dataset.layers);
+    var layers = layersData.map(function (layer) {
+        var source = new ol.source.Zoomify({
+            url: layer.url,
+            size: layer.size,
+            crossOrigin: 'anonymous',
+            zDirection: -1,
+        });
+        return new ol.layer.Tile({ title: layer.name, source: source });
+    });
+    var resolutions = layers[0].getSource().getTileGrid().getResolutions();
+    var extent = layers[0].getSource().getTileGrid().getExtent();
+    var projection = new ol.proj.Projection({
+        code: 'Zoomify',
+        units: 'pixels',
+        extent: extent,
+        metersPerUnit: layersData[0].mpp * 1e-6,
+        getPointResolution: function(r){ return r; }
+    });
+    var view = new ol.View({
+        projection: projection,
+        resolutions: resolutions,
+        constrainOnlyCenter: true,
+    });
+    var vectorSource = new ol.source.Vector();
+    var vectorLayer = new ol.layer.Vector({ source: vectorSource });
+    layers.push(vectorLayer);
+    var map = new ol.Map({ target: 'map', layers: layers, view: view });
+    map.getView().fit(extent);
+
+    fetchAnnotations(vectorSource, map.getView().calculateExtent());
+    map.on('moveend', function() {
+        var b = map.getView().calculateExtent();
+        fetchAnnotations(vectorSource, b);
+    });
+}
+
+function fetchAnnotations(source, bounds) {
+    var params = new URLSearchParams();
+    params.append('bounds', JSON.stringify(bounds));
+    params.append('where', JSON.stringify(null));
+    fetch('/tileserver/vector_annotations?' + params.toString())
+        .then(function(r){ return r.json(); })
+        .then(function(data){
+            var format = new ol.format.GeoJSON();
+            var feats = format.readFeatures(data, {featureProjection: 'Zoomify'});
+            source.clear();
+            source.addFeatures(feats);
+        });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/tiatoolbox/visualization/openlayers_app/templates/index.html
+++ b/tiatoolbox/visualization/openlayers_app/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/css/ol.css" />
+    <script src="/js/ol.js"></script>
+    <script src="/js/ol-ext.min.js"></script>
+    <style>
+        html, body { height: 100%; margin: 0; }
+        #map { width: 100%; height: 100%; }
+    </style>
+    <title>TIAToolbox OpenLayers</title>
+</head>
+<body>
+<div id="map" data-layers="{{ layers }}"></div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/tiatoolbox/visualization/tileserver.py
+++ b/tiatoolbox/visualization/tileserver.py
@@ -163,6 +163,10 @@ class TileServer(Flask):
         self.route("/tileserver/slide", methods=["GET"])(self.get_slide)
         self.route("/tileserver/cmap", methods=["GET"])(self.get_mapper)
         self.route("/tileserver/annotations", methods=["GET"])(self.get_annotations)
+        self.route(
+            "/tileserver/vector_annotations",
+            methods=["GET"],
+        )(self.get_vector_annotations)
         self.route("/tileserver/overlay", methods=["GET"])(self.get_overlay)
         self.route("/tileserver/renderer/<prop>", methods=["GET"])(self.get_renderer)
         self.route("/tileserver/secondary_cmap", methods=["GET"])(
@@ -688,6 +692,25 @@ class TileServer(Flask):
             for ann in annotations.values()
         ]
         return jsonify(annotations)
+
+    def get_vector_annotations(self: TileServer) -> Response:
+        """Return annotations as GeoJSON features."""
+        session_id = self._get_session_id()
+        bounds = json.loads(request.args.get("bounds"))
+        where = json.loads(request.args.get("where"))
+        anns = self.get_ann_layer(session_id).store.query(
+            geometry=bounds,
+            where=where,
+        )
+        features = [
+            {
+                "type": "Feature",
+                "geometry": ann.geometry.__geo_interface__,
+                "properties": ann.properties,
+            }
+            for ann in anns.values()
+        ]
+        return jsonify({"type": "FeatureCollection", "features": features})
 
     def get_overlay(self: TileServer) -> Response:
         """Get the overlay info."""


### PR DESCRIPTION
## Summary
- serve a new OpenLayers-based viewer
- add endpoint returning annotations as GeoJSON for vector layers

## Testing
- `pip install pytest` *(fails: cannot connect to proxy)*