### PR TITLE
Add minimal UI for OpenLayers viewer

### DIFF
--- a/tiatoolbox/visualization/openlayers_app/__init__.py
+++ b/tiatoolbox/visualization/openlayers_app/__init__.py
@@ -1,0 +1,1 @@
+"""OpenLayers based viewer."""

--- a/tiatoolbox/visualization/openlayers_app/app.py
+++ b/tiatoolbox/visualization/openlayers_app/app.py
@@ -1,3 +1,5 @@
+"""OpenLayers based tile server application."""
+
 from __future__ import annotations
 
 import json
@@ -19,6 +21,7 @@ class OpenLayersServer(TileServer):
         slide_folder: str | None = None,
         overlay_folder: str | None = None,
     ) -> None:
+        """Create an :class:`OpenLayersServer` instance."""
         self.slide_folder = Path(slide_folder) if slide_folder else None
         self.overlay_folder = Path(overlay_folder) if overlay_folder else None
         super().__init__(title=title, layers=layers)
@@ -26,16 +29,22 @@ class OpenLayersServer(TileServer):
     def index(self) -> str:  # type: ignore[override]
         """Serve the index page with slide and overlay lists."""
         session_id = self._get_session_id()
-        layers = [
-            {
-                "name": name,
-                "url": f"/tileserver/layer/{name}/default/zoomify/"
-                "{TileGroup}/{z}-{x}-{y}@1x.jpg",
-                "size": [int(x) for x in layer.info.slide_dimensions],
-                "mpp": float(np.mean(layer.info.mpp)),
-            }
-            for name, layer in self.layers[session_id].items()
-        ]
+        resp = None
+        if (session_id is None) or (session_id not in self.layers):
+            resp = self.session_id()
+            # no layers loaded yet for a new session
+            layers: list[dict] = []
+        else:
+            layers = [
+                {
+                    "name": name,
+                    "url": f"/tileserver/layer/{name}/default/zoomify/"
+                    "{TileGroup}/{z}-{x}-{y}@1x.jpg",
+                    "size": [int(x) for x in layer.info.slide_dimensions],
+                    "mpp": float(np.mean(layer.info.mpp)),
+                }
+                for name, layer in self.layers[session_id].items()
+            ]
 
         slide_opts: list[str] = []
         overlay_opts: list[str] = []
@@ -70,13 +79,17 @@ class OpenLayersServer(TileServer):
             ]:
                 overlay_opts.extend(sorted(map(str, self.overlay_folder.glob(ext))))
 
-        return render_template(
+        rendered = render_template(
             "index.html",
             title=self.title,
             layers=json.dumps(layers),
             slide_options=slide_opts,
             overlay_options=overlay_opts,
         )
+        if resp is None:
+            return rendered
+        resp.set_data(rendered)
+        return resp
 
 
 def create_app(
@@ -84,6 +97,7 @@ def create_app(
     slide_folder: str | None = None,
     overlay_folder: str | None = None,
 ) -> TileServer:
+    """Return a ready-to-run :class:`TileServer` instance."""
     layers: dict[str, str] = {}
     if slide is not None:
         layers = {"slide": slide}
@@ -101,4 +115,4 @@ def create_app(
 
 
 if __name__ == "__main__":
-    create_app().run(host="0.0.0.0", threaded=True)
+    create_app().run(host="0.0.0.0", threaded=True)  # noqa: S104

--- a/tiatoolbox/visualization/openlayers_app/app.py
+++ b/tiatoolbox/visualization/openlayers_app/app.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from flask.templating import render_template
+
+from tiatoolbox.visualization.tileserver import TileServer
+
+
+class OpenLayersServer(TileServer):
+    """TileServer subclass serving an OpenLayers front-end."""
+
+    def __init__(
+        self,
+        title: str,
+        layers: dict[str, str] | list[str],
+        slide_folder: str | None = None,
+        overlay_folder: str | None = None,
+    ) -> None:
+        self.slide_folder = Path(slide_folder) if slide_folder else None
+        self.overlay_folder = Path(overlay_folder) if overlay_folder else None
+        super().__init__(title=title, layers=layers)
+
+    def index(self) -> str:  # type: ignore[override]
+        """Serve the index page with slide and overlay lists."""
+        session_id = self._get_session_id()
+        layers = [
+            {
+                "name": name,
+                "url": f"/tileserver/layer/{name}/default/zoomify/"
+                "{TileGroup}/{z}-{x}-{y}@1x.jpg",
+                "size": [int(x) for x in layer.info.slide_dimensions],
+                "mpp": float(np.mean(layer.info.mpp)),
+            }
+            for name, layer in self.layers[session_id].items()
+        ]
+
+        slide_opts: list[str] = []
+        overlay_opts: list[str] = []
+        if self.slide_folder:
+            for ext in [
+                "*.svs",
+                "*.ndpi",
+                "*.tiff",
+                "*.tif",
+                "*.mrxs",
+                "*.png",
+                "*.jpg",
+                "*.qptiff",
+            ]:
+                slide_opts.extend(sorted(map(str, self.slide_folder.glob(ext))))
+        if self.overlay_folder:
+            for ext in [
+                "*.db",
+                "*.dat",
+                "*.geojson",
+                "*.png",
+                "*.jpg",
+                "*.json",
+                "*.tiff",
+                "*.pkl",
+                "*.mrxs",
+                "*.ndpi",
+                "*.svs",
+                "*.tif",
+                "*.npy",
+                "*.mha",
+            ]:
+                overlay_opts.extend(sorted(map(str, self.overlay_folder.glob(ext))))
+
+        return render_template(
+            "index.html",
+            title=self.title,
+            layers=json.dumps(layers),
+            slide_options=slide_opts,
+            overlay_options=overlay_opts,
+        )
+
+
+def create_app(
+    slide: str | None = None,
+    slide_folder: str | None = None,
+    overlay_folder: str | None = None,
+) -> TileServer:
+    layers: dict[str, str] = {}
+    if slide is not None:
+        layers = {"slide": slide}
+    app = OpenLayersServer(
+        title="TIAToolbox OpenLayers",
+        layers=layers,
+        slide_folder=slide_folder,
+        overlay_folder=overlay_folder,
+    )
+    tpl = Path(__file__).parent / "templates"
+    static = Path(__file__).parent / "static"
+    app.jinja_loader.searchpath.insert(0, str(tpl))
+    app.static_folder = str(static)
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(host="0.0.0.0", threaded=True)

--- a/tiatoolbox/visualization/openlayers_app/app.py
+++ b/tiatoolbox/visualization/openlayers_app/app.py
@@ -1,9 +1,12 @@
+"""OpenLayers based tile server application."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
 import numpy as np
+from flask import send_from_directory
 from flask.templating import render_template
 
 from tiatoolbox.visualization.tileserver import TileServer
@@ -19,6 +22,7 @@ class OpenLayersServer(TileServer):
         slide_folder: str | None = None,
         overlay_folder: str | None = None,
     ) -> None:
+        """Create an :class:`OpenLayersServer` instance."""
         self.slide_folder = Path(slide_folder) if slide_folder else None
         self.overlay_folder = Path(overlay_folder) if overlay_folder else None
         super().__init__(title=title, layers=layers)
@@ -26,16 +30,22 @@ class OpenLayersServer(TileServer):
     def index(self) -> str:  # type: ignore[override]
         """Serve the index page with slide and overlay lists."""
         session_id = self._get_session_id()
-        layers = [
-            {
-                "name": name,
-                "url": f"/tileserver/layer/{name}/default/zoomify/"
-                "{TileGroup}/{z}-{x}-{y}@1x.jpg",
-                "size": [int(x) for x in layer.info.slide_dimensions],
-                "mpp": float(np.mean(layer.info.mpp)),
-            }
-            for name, layer in self.layers[session_id].items()
-        ]
+        resp = None
+        if (session_id is None) or (session_id not in self.layers):
+            resp = self.session_id()
+            # no layers loaded yet for a new session
+            layers: list[dict] = []
+        else:
+            layers = [
+                {
+                    "name": name,
+                    "url": f"/tileserver/layer/{name}/default/zoomify/"
+                    "{TileGroup}/{z}-{x}-{y}@1x.jpg",
+                    "size": [int(x) for x in layer.info.slide_dimensions],
+                    "mpp": float(np.mean(layer.info.mpp)),
+                }
+                for name, layer in self.layers[session_id].items()
+            ]
 
         slide_opts: list[str] = []
         overlay_opts: list[str] = []
@@ -70,13 +80,17 @@ class OpenLayersServer(TileServer):
             ]:
                 overlay_opts.extend(sorted(map(str, self.overlay_folder.glob(ext))))
 
-        return render_template(
+        rendered = render_template(
             "index.html",
             title=self.title,
             layers=json.dumps(layers),
             slide_options=slide_opts,
             overlay_options=overlay_opts,
         )
+        if resp is None:
+            return rendered
+        resp.set_data(rendered)
+        return resp
 
 
 def create_app(
@@ -84,6 +98,7 @@ def create_app(
     slide_folder: str | None = None,
     overlay_folder: str | None = None,
 ) -> TileServer:
+    """Return a ready-to-run :class:`TileServer` instance."""
     layers: dict[str, str] = {}
     if slide is not None:
         layers = {"slide": slide}
@@ -96,9 +111,13 @@ def create_app(
     tpl = Path(__file__).parent / "templates"
     static = Path(__file__).parent / "static"
     app.jinja_loader.searchpath.insert(0, str(tpl))
-    app.static_folder = str(static)
+    app.add_url_rule(
+        "/main.js",
+        endpoint="openlayers_main_js",
+        view_func=lambda: send_from_directory(static, "main.js"),
+    )
     return app
 
 
 if __name__ == "__main__":
-    create_app().run(host="0.0.0.0", threaded=True)
+    create_app().run(host="0.0.0.0", threaded=True)  # noqa: S104

--- a/tiatoolbox/visualization/openlayers_app/static/main.js
+++ b/tiatoolbox/visualization/openlayers_app/static/main.js
@@ -1,0 +1,84 @@
+function init() {
+    var dataElement = document.getElementById('map');
+    var layersData = JSON.parse(dataElement.dataset.layers);
+    var layers = layersData.map(function (layer) {
+        var source = new ol.source.Zoomify({
+            url: layer.url,
+            size: layer.size,
+            crossOrigin: 'anonymous',
+            zDirection: -1,
+        });
+        return new ol.layer.Tile({ title: layer.name, source: source });
+    });
+    var resolutions = layers[0].getSource().getTileGrid().getResolutions();
+    var extent = layers[0].getSource().getTileGrid().getExtent();
+    var projection = new ol.proj.Projection({
+        code: 'Zoomify',
+        units: 'pixels',
+        extent: extent,
+        metersPerUnit: layersData[0].mpp * 1e-6,
+        getPointResolution: function(r){ return r; }
+    });
+    var view = new ol.View({
+        projection: projection,
+        resolutions: resolutions,
+        constrainOnlyCenter: true,
+    });
+    var vectorSource = new ol.source.Vector();
+    var vectorLayer = new ol.layer.Vector({ source: vectorSource });
+    layers.push(vectorLayer);
+    var map = new ol.Map({ target: 'map', layers: layers, view: view });
+    map.getView().fit(extent);
+
+    setupUI();
+
+    fetchAnnotations(vectorSource, map.getView().calculateExtent());
+    map.on('moveend', function() {
+        var b = map.getView().calculateExtent();
+        fetchAnnotations(vectorSource, b);
+    });
+}
+
+function fetchAnnotations(source, bounds) {
+    var params = new URLSearchParams();
+    params.append('bounds', JSON.stringify(bounds));
+    params.append('where', JSON.stringify(null));
+    fetch('/tileserver/vector_annotations?' + params.toString())
+        .then(function(r){ return r.json(); })
+        .then(function(data){
+            var format = new ol.format.GeoJSON();
+            var feats = format.readFeatures(data, {featureProjection: 'Zoomify'});
+            source.clear();
+            source.addFeatures(feats);
+        });
+}
+
+document.addEventListener('DOMContentLoaded', init);
+
+function setupUI() {
+    var slideSelect = document.getElementById('slideSelect');
+    if (slideSelect) {
+        slideSelect.addEventListener('change', function() {
+            var val = slideSelect.value;
+            if (!val) { return; }
+            fetch('/tileserver/slide', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: 'slide_path=' + encodeURIComponent(val)
+            }).then(function(){ location.reload(); });
+        });
+    }
+
+    var overlaySelect = document.getElementById('overlaySelect');
+    if (overlaySelect) {
+        overlaySelect.addEventListener('change', function() {
+            var val = overlaySelect.value;
+            if (!val) { return; }
+            fetch('/tileserver/overlay', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: 'overlay_path=' + encodeURIComponent(val)
+            }).then(function(){ location.reload(); });
+        });
+    }
+}

--- a/tiatoolbox/visualization/openlayers_app/templates/index.html
+++ b/tiatoolbox/visualization/openlayers_app/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/css/ol.css" />
+    <script src="/js/ol.js"></script>
+    <script src="/js/ol-ext.min.js"></script>
+    <style>
+        html, body { height: 100%; margin: 0; }
+        #map { width: 100%; height: calc(100% - 40px); }
+        #controls { height: 40px; padding: 5px; background: #eee; }
+    </style>
+    <title>TIAToolbox OpenLayers</title>
+</head>
+<body>
+<div id="controls">
+    <label>Slide:
+        <select id="slideSelect">
+            {% for s in slide_options %}
+            <option value="{{ s }}">{{ s }}</option>
+            {% endfor %}
+        </select>
+    </label>
+    <label>Overlay:
+        <select id="overlaySelect">
+            <option value="">None</option>
+            {% for o in overlay_options %}
+            <option value="{{ o }}">{{ o }}</option>
+            {% endfor %}
+        </select>
+    </label>
+</div>
+<div id="map" data-layers="{{ layers }}"></div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/tiatoolbox/visualization/tileserver.py
+++ b/tiatoolbox/visualization/tileserver.py
@@ -163,6 +163,10 @@ class TileServer(Flask):
         self.route("/tileserver/slide", methods=["GET"])(self.get_slide)
         self.route("/tileserver/cmap", methods=["GET"])(self.get_mapper)
         self.route("/tileserver/annotations", methods=["GET"])(self.get_annotations)
+        self.route(
+            "/tileserver/vector_annotations",
+            methods=["GET"],
+        )(self.get_vector_annotations)
         self.route("/tileserver/overlay", methods=["GET"])(self.get_overlay)
         self.route("/tileserver/renderer/<prop>", methods=["GET"])(self.get_renderer)
         self.route("/tileserver/secondary_cmap", methods=["GET"])(
@@ -688,6 +692,25 @@ class TileServer(Flask):
             for ann in annotations.values()
         ]
         return jsonify(annotations)
+
+    def get_vector_annotations(self: TileServer) -> Response:
+        """Return annotations as GeoJSON features."""
+        session_id = self._get_session_id()
+        bounds = json.loads(request.args.get("bounds"))
+        where = json.loads(request.args.get("where"))
+        anns = self.get_ann_layer(session_id).store.query(
+            geometry=bounds,
+            where=where,
+        )
+        features = [
+            {
+                "type": "Feature",
+                "geometry": ann.geometry.__geo_interface__,
+                "properties": ann.properties,
+            }
+            for ann in anns.values()
+        ]
+        return jsonify({"type": "FeatureCollection", "features": features})
 
     def get_overlay(self: TileServer) -> Response:
         """Get the overlay info."""


### PR DESCRIPTION
## Summary
- expose slide and overlay folders in a dedicated `OpenLayersServer`
- serve dropdown controls to pick slides and overlays
- hook dropdowns to backend endpoints for switching layers

## Testing
- `pip install pytest` *(fails: cannot connect to proxy)*